### PR TITLE
Changed default keybindings to avoid collision with goto text

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,4 +1,4 @@
 [
-  { "keys": ["super+;"], "command": "append_semi_colon" }, 
-  { "keys": ["super+shift+;"], "command": "append_semi_colon", "args": {"enter_new_line": "true"} }
+  { "keys": ["alt+;"], "command": "append_semi_colon" },
+  { "keys": ["alt+super+;"], "command": "append_semi_colon", "args": {"enter_new_line": "true"} }
 ]

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,4 +1,4 @@
 [
-  { "keys": ["ctrl+;"], "command": "append_semi_colon" }, 
-  { "keys": ["ctrl+shift+;"], "command": "append_semi_colon", "args": {"enter_new_line": "true"} }
+  { "keys": ["alt+;"], "command": "append_semi_colon" },
+  { "keys": ["alt+ctrl+;"], "command": "append_semi_colon", "args": {"enter_new_line": "true"} }
 ]


### PR DESCRIPTION
In ST3, the key combination "ctrl+;" is bound to open the goto text (fuzzy search in file) by default. Changing the default keybinding to use the alt key instead would avoid this collision. Also, on my English keyboard on Linux, the OS converts "shift+;" into ":" before handing the key to sublime. Thus, the "append semicolon and start newline" command is inaccessible by default. The switch to "alt+ctrl+;" (or for Mac OS X to "alt+super+;") avoids this problem.
